### PR TITLE
Update links to CBS

### DIFF
--- a/docs/computing/cbs.md
+++ b/docs/computing/cbs.md
@@ -16,11 +16,15 @@ of Canada servers).
 
 {: .important}
 Form for new user sign-up (**select Basic user unless you have discussed this with your supervisor(s)**): 
-[https://forms.office.com/r/sQepNZDNqS](https://forms.office.com/r/sQepNZDNqS)
+[https://forms.office.com/r/mdmWQ6qpep](https://forms.office.com/r/mdmWQ6qpep)
 
 All Khanlab users will automatically be granted access to a CBS basic (standard)
 account. Please contact Dr. Khan if you need a CBS heavy account (more 
 computational resources).
+
+{: .note}
+If you need to make a change to an existing account, use the following link:
+[https://forms.office.com/r/sQepNZDNqS](https://forms.office.com/r/sQepNZDNqS)
 
 ## Additional resources
 * [CBS Wiki](https://osf.io/k89fh/wiki/Computational%20Core%20Server/)

--- a/docs/onboarding/access.md
+++ b/docs/onboarding/access.md
@@ -17,7 +17,7 @@ You can then activate your identity
 
 ## Robarts Login
 Our lab makes use of a virtual desktop infrastructure (VDI) server at Robarts, so that all users can access the same graphical user interface on a Ubuntu Linux system. 
-To sign up for a user, fill out the following [form](https://forms.office.com/r/sQepNZDNqS). Please select basic user unless you have discussed this with your supervisor(s).
+To sign up for a user, fill out the following [form](https://forms.office.com/r/mdmWQ6qpep). Please select basic user unless you have discussed this with your supervisor(s).
 
 All Khanlab users will automatically be granted access to a CBS basic (standard) account. Please contact Dr. Khan if you need a CBS heavy account (more computational resources).
 


### PR DESCRIPTION
Wiki was directing new users to the "Update account" form for a new-user sign up. This PR fixes this and additionally adds a note linking to account updates.